### PR TITLE
Enhance README file by adding a link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
-# Orange Design System - iOS components
+<p align="center">
+  <a href="https://orange-opensource.github.io/ods-ios">
+    <img src="https://c.woopic.com/logo-orange.png" alt="ODS iOS" width="50" height="50">
+  </a>
+</p>
 
-The goal of this project is to provide developers with Orange branded UI components.
-A demo application is also provided.
+<h3 align="center">ODS iOS</h3>
 
-Orange Design System project also provides Web and Android components, See :
+<p align="center">
+  ODS iOS provides Orange iOS components to developers and a demo application.
+  <br>
+  <a href="https://orange-opensource.github.io/ods-ios"><strong>Visit ODS iOS</strong></a>
+  <br>
+  <br>
+  <a href="https://github.com/Orange-OpenSource/ods-ios/issues/new?assignees=B3nz01d&labels=bug%2Ctriage&template=bug_report.yml&title=%5BBug%5D%3A+Bug+Summary">Report bug</a>
+  ·
+  <a href="https://github.com/Orange-OpenSource/ods-ios/issues/new?assignees=B3nz01d&labels=feature%2Ctriage&template=feature_request.yml&title=%5Bfeature%5D%3A+">Request feature</a>
+</p>
 
-* [ODS Android] (https://github.com/Orange-OpenSource/ods-android)
-* [ODS Web - Boosted] (https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap)  


### PR DESCRIPTION
This PR is a proposal to:
* Enhance the README file to be consistent with [the one from Boosted](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/main/README.md).
* Add a link to the documentation