### PR TITLE
Fix issues templates + `README.md` links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Report a bug
 description: Tell us about a bug or issue you may have identified in ODS iOS.
 title: "[Bug]: Bug Summary"
-labels: ["bug", "triage"]
+labels: ["🐞 bug", "🔍 triage"]
 assignees: 
   - B3nz01d
 body:

--- a/.github/ISSUE_TEMPLATE/documentation-update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-update.yml
@@ -1,7 +1,7 @@
 name: Documentation Update
 description: Describe this issue found in the documentation
 title: "[Doc]: "
-labels: ["documentation", "triage"]
+labels: ["📖+documentation", "🔍 triage"]
 assignees: 
   - B3nz01d
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new Epic to be added to the backlog.
 title: "[feature]: "
-labels: ["feature", "triage"]
+labels: ["feature", "🔍 triage"]
 assignees: 
   - B3nz01d
 body:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   <a href="https://orange-opensource.github.io/ods-ios"><strong>Visit ODS iOS</strong></a>
   <br>
   <br>
-  <a href="https://github.com/Orange-OpenSource/ods-ios/issues/new?assignees=B3nz01d&labels=bug%2Ctriage&template=bug_report.yml&title=%5BBug%5D%3A+Bug+Summary">Report bug</a>
+  <a href="https://github.com/Orange-OpenSource/ods-ios/issues/new?assignees=B3nz01d&labels=%F0%9F%90%9E%20bug%2C%F0%9F%94%8D+triage&template=bug_report.yml&title=[Bug]%3A+Bug+Summary">Report bug</a>
   ·
-  <a href="https://github.com/Orange-OpenSource/ods-ios/issues/new?assignees=B3nz01d&labels=feature%2Ctriage&template=feature_request.yml&title=%5Bfeature%5D%3A+">Request feature</a>
+  <a href="https://github.com/Orange-OpenSource/ods-ios/issues/new?assignees=B3nz01d&labels=feature%2C%F0%9F%94%8D%20triage&template=feature_request.yml&title=[feature]%3A+">Request feature</a>
 </p>
 


### PR DESCRIPTION
This PR fixes the links in `README.md` leading to issue templates.

Before, by clicking on them, contrary to the normal process of the creation of the issues, the issue template was not containing the labels.

Live preview to check the links: https://github.com/julien-deramond/ods-ios/blob/938ed3c562410ca8aa84afca3b1a997f6d8057ca/README.md

On top of that, this PR also fixes the labels used when creating issues from the forms. I used the same principle as in https://raw.githubusercontent.com/Orange-OpenSource/ods-flutter/main/.github/ISSUE_TEMPLATE/bug_report.yml, so should work 🤞 