### PR TITLE
[#598] Title and subtitile on several lines for small cards if accessible size in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- [SDK/DemoApp] Display title and subtitle in small cards if accessiibility size is used (Bug [#598](https://github.com/Orange-OpenSource/ods-ios/issues/598))
 ## [0.16.0]\(https://github.com/Orange-OpenSource/ods-ios/compare/0.16.0...0.15.0) - 2024-01-15
 
 - [SDK/DemoApp] Options are overlapped in Setup page of the about module. This needs update in Chips Pickers (Bug [#577] (https://github.com/Orange-OpenSource/ods-ios/issues/577))

--- a/OrangeDesignSystem/Sources/OrangeDesignSystem/Components/Cards/ODSCardSmall.swift
+++ b/OrangeDesignSystem/Sources/OrangeDesignSystem/Components/Cards/ODSCardSmall.swift
@@ -13,12 +13,15 @@ import SwiftUI
 ///
 /// A small card is a card which can be added in two columns grid.
 /// It contains an image and a title, and an optional subtitle placed below.
+/// If the accessibility sizes are used (i.e. greater or equal than 160%), title and subtitle are on more than one line.
 ///
 public struct ODSCardSmall: View {
 
     private let title: Text
     private let subtitle: Text?
     private let imageSource: ODSImage.Source
+
+    @Environment(\.sizeCategory) private var sizeCategory
 
     // =================
     // MARK: Initializer
@@ -51,12 +54,12 @@ public struct ODSCardSmall: View {
 
             VStack(alignment: .leading, spacing: ODSSpacing.xs) {
                 title
-                    .lineLimit(1)
+                    .lineLimit(sizeCategory.isAccessibilityCategory ? nil : 1)
                     .odsFont(.bodyLBold)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 subtitle?
-                    .lineLimit(1)
+                    .lineLimit(sizeCategory.isAccessibilityCategory ? nil : 1)
                     .odsFont(.bodyLRegular)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }


### PR DESCRIPTION
# Bug

#598 

# Definition of Done

- [ ] Update CHANGELOG
- [ ] Add controls to define line limits of title and subtitle in small cards if a11y size used

# Screen shots

## Small cards with 310% size

![#598 - iPhone 12 Pro (iOS 17 0 01) - light mode - small cards grid with size 310 percent](https://github.com/Orange-OpenSource/ods-ios/assets/7559007/fd411681-662e-4335-9223-f043482212ce)

## Small cards with 235% size

![#598 - iPhone 12 Pro (iOS 17 0 01) - light mode - small cards grid with size 235 percent](https://github.com/Orange-OpenSource/ods-ios/assets/7559007/2913e2e1-d8c5-4e56-8508-63b1f8773cb6)

## Small cards with 160% size

![#598 - iPhone 12 Pro (iOS 17 0 01) - light mode - small cards grid with size 160 percent](https://github.com/Orange-OpenSource/ods-ios/assets/7559007/37da7835-05fd-4667-8f03-73ae6cba7fc4)
