### PR TITLE
[#610] Fastlane lane for CI/CD build with Apps Plus credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- [Tooling] Add Fastlane lane to copy Apps Plus credentials in CI/CD chain for nightly and release builds ([#610](https://github.com/Orange-OpenSource/ods-ios/issues/610))
 - [DemoApp] Update technical documentation with versions of tools ([#549](https://github.com/Orange-OpenSource/ods-ios/issues/549))
 - [DemoApp/SDK] Apps recirculation ([#64](https://github.com/Orange-OpenSource/ods-ios/issues/64))
 

--- a/OrangeDesignSystemDemo/OrangeDesignSystemDemo/Resources/Info.plist
+++ b/OrangeDesignSystemDemo/OrangeDesignSystemDemo/Resources/Info.plist
@@ -4,10 +4,10 @@
 <dict>
 	<key>APPS_PLUS_URL</key>
 	<string>${APPS_PLUS_URL}</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleAllowMixedLocalizations</key>
 	<true/>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleSpokenName</key>
 	<string>Orange Design System</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>

--- a/OrangeDesignSystemDemo/fastlane/Fastfile
+++ b/OrangeDesignSystemDemo/fastlane/Fastfile
@@ -11,6 +11,8 @@ APPLE_KEY_ID = ENV["ODS_APPLE_KEY_ID"]
 APPLE_KEY_CONTENT = ENV["ODS_APPLE_KEY_CONTENT"]
 DEVELOPER_APP_IDENTIFIER = ENV["ODS_DEVELOPER_APP_IDENTIFIER"]
 
+APPS_PLUS_SERVICE_URL = ENV["ODS_APPS_PLUS_SERVICE_URL"]
+
 MATTERMOST_HOOK_URL = ENV["ODS_MATTERMOST_HOOK_URL"]
 MATTERMOST_HOOK_BOT_NAME = ENV["ODS_MATTERMOST_HOOK_BOT_NAME"]
 MATTERMOST_HOOK_BOT_ICON_URL = ENV["ODS_MATTERMOST_HOOK_BOT_ICON_URL"]
@@ -42,6 +44,19 @@ platform :ios do
     end
   end
     
+  # ------------------------------------------------------------
+  # ADD APPS PLUS CREDENTIALS (About module)
+  # ------------------------------------------------------------
+  desc "ADD APPS PLUS CREDENTIALS"
+  lane :add_credentials_appsplus do
+    update_plist(
+      plist_path: "OrangeDesignSystemDemo/Resources/Info.plist",
+      block: proc do |plist|
+        plist[:APPS_PLUS_URL] = APPS_PLUS_SERVICE_URL
+      end
+    )
+  end
+
   # ------------------------------------------------------------
   # UPDATE BUILD NUMBER WITH TIMESTAMP
   # ------------------------------------------------------------

--- a/OrangeDesignSystemDemo/fastlane/README.md
+++ b/OrangeDesignSystemDemo/fastlane/README.md
@@ -23,6 +23,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 RUN TESTS BY TRIGGERING THE TESTS PLANS OF THE PROJECT
 
+### ios add_credentials_appsplus
+
+```sh
+[bundle exec] fastlane ios add_credentials_appsplus
+```
+
+ADD APPS PLUS CREDENTIALS
+
 ### ios increment
 
 ```sh

--- a/docs/modules/about.md
+++ b/docs/modules/about.md
@@ -366,12 +366,12 @@ let moreAppsItem = ODSMoreAppsItemConfig(source: ..., enableHaptics: false)
 
 #### Define some configuration in your app
 
-You can for example for your app use a _AppDemoConfig.xcconfig_ configuration file to store such credentials.
+You can for example for your app use a _.xcconfig_ configuration settings file to store such credentials.
 A key named **APPS_PLUS_URL** can be defined with the URL (containing the API key) to call.
 Then the **Info.plist** file of your app must have an entry with the same name.
-Of course the _AppDemoConfig.xcconfig_ file should not be versionned in Git, but our demo app implements this feature.
+Of course the _.xcconfig_ file should not be versionned in Git, but our demo app implements this feature (see _AppDemoConfig.xcconfig_).
 
-See the example for the .xcconfig :
+See the example for the _.xcconfig_:
 
 ```text
 // Configuration settings file format documentation can be found at:
@@ -384,14 +384,14 @@ APPS_PLUS_URL = https:/$()/url-to-api?apikey=$(APPS_PLUS_API_KEY)
 // Here $() prevents the // to be interpreted as comment, we suppose the URL has an apikey parameter and is GET only
 ```
 
-And the entry for the Info.plist :
+And the entry for the _Info.plist_:
 
 ```text
-    <key>APPS_PLUS_URL</key>
-    <string>${APPS_PLUS_URL}</string> <!-- Or write here the full URL with API key but without lang -->
+    <key>APPS_PLUS_URL</key> <!-- Key used in the demo app code -->
+    <string>${APPS_PLUS_URL}</string> <!-- Key in the xcconfig side, or write here the full URL with API key but without lang -->
 ```
 
-Then in our code we just read the URL, get the local, and forge the final URL to give to `ODSMoreAppsItemConfig`.
+Then in our code we just read the URL, get the locale, and forge the final URL to give to `ODSMoreAppsItemConfig`.
 We could have choosen this implemention deeper in the repository but wanted to let ODS lib users choose their own way to deal with the URL.
 
 ```swift
@@ -408,4 +408,7 @@ We could have choosen this implemention deeper in the repository but wanted to l
     }
     
     // And then ODSMoreAppsItemConfig(source: .remote(url: buildAppsPlusURL()))
-``
+```
+
+In some CI/CD chain, like our old-school Jenkins server with Groovy pipelines, we can use a _Fastlane_ lane to read some previously environment variable and
+fill the _Info.Plist_ file in the suitable row.

--- a/docs_release/README.md
+++ b/docs_release/README.md
@@ -126,9 +126,9 @@ This file lists all the steps to follow when releasing a new version of ODS iOS.
 
 ## [About CI/CD with Jenkins]
 
-You can setup in your side a _Jenkins_ runner which can trigger some Fastlane actions for example each night.
+You can setup in your side a _Jenkins_ runner which can trigger some _Fastlane_ actions for example each night.
 
-YOu can find bellow some pipeline script to fill and use:
+You can find bellow some pipeline script to fill and use:
 
 ```groovy
 pipeline {
@@ -145,7 +145,7 @@ pipeline {
         }
         
         stage('Tests') {
-            // Of course you must file all these environment variables
+            // Of course you must fill all these environment variables
             environment {
                 ODS_MATTERMOST_HOOK_URL = ...
                 ODS_MATTERMOST_HOOK_BOT_NAME = ...
@@ -169,6 +169,9 @@ pipeline {
                 ODS_APPLE_ISSUER_ID = ...
                 ODS_APPLE_KEY_CONTENT = ...
                 
+                // Credentials to fill in the app
+                ODS_APPS_PLUS_SERVICE_URL = "https://url-to-api?apikey=APPS_PLUS_API_KEY"
+
                 // Mattermost webhooks notifications
                 ODS_MATTERMOST_HOOK_URL = ...
                 ODS_MATTERMOST_HOOK_BOT_NAME = ...
@@ -176,6 +179,7 @@ pipeline {
             }
             steps {
                 dir('OrangeDesignSystemDemo') {
+                    sh "bundle exec fastlane add_credentials_appsplus"
                     sh "bundle exec fastlane qualif"
                 }
             }


### PR DESCRIPTION
# Issue

#610 

# Definition of Done

- [x] Update documentation
- [x] Update CHANGELOG
- [x] Update about
- [x] Update README
- [x] Update Fastlane lane in Fastfile

# Details

- For developers, use the xcconfig file with credntials, unversioned
- For CI/CD, define an environment variable and run a lane
- The lane will just update the Info.plist, exactly like thr Xcode magic with its xcconfig file