### PR TITLE
[Hotfix] Xcode 14 issue

### DIFF
--- a/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Internal/ListItems/MoreApps/MoreAppsViewModel.swift
+++ b/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Internal/ListItems/MoreApps/MoreAppsViewModel.swift
@@ -76,10 +76,8 @@ final class MoreAppsViewModel: ObservableObject {
     // swiftlint:enable force_cast
 
     func appImage(at url: URL) -> ODSImage.Source {
-        if cacheAppsIcons {
-            .cachedAsyncImage(url, Image("ods_empty", bundle: Bundle.ods))
-        } else {
-            .asyncImage(url, Image("ods_empty", bundle: Bundle.ods))
-        }
+        return cacheAppsIcons
+            ? ODSImage.Source.cachedAsyncImage(url, Image("ods_empty", bundle: Bundle.ods))
+            : ODSImage.Source.asyncImage(url, Image("ods_empty", bundle: Bundle.ods))
     }
 }


### PR DESCRIPTION
Fix "reference to member 'cachedAsyncImage' cannot be resolved without a contextual type"

```text
[31m❌  [XXX/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Internal/ListItems/MoreApps/MoreAppsViewModel.swift:80:14: [31mreference to member 'cachedAsyncImage' cannot be resolved without a contextual type[0m

            .cachedAsyncImage(url, Image("ods_empty", bundle: Bundle.ods))
[36m            ~^~~~~~~~~~~~~~~~[0m



[31m❌  [XXX/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Internal/ListItems/MoreApps/MoreAppsViewModel.swift:82:14: [31mreference to member 'asyncImage' cannot be resolved without a contextual type[0m
```