### PR TITLE
Various cleanings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [SDK/DemoApp] Display accessibility conformity status instead of simple title wording for accessibility statement menu entry ([#772](https://github.com/Orange-OpenSource/ods-ios/issues/772))
 - [SDK/DemoApp] Create Recirculation module and update About module to use it ([#684](https://github.com/Orange-OpenSource/ods-ios/issues/684))
 - [Tooling/DemoApp] Display build tag in about screen for beta releases (TestFlight)
 - [SDK/DemoApp] Add ODSEmptyState module ([#558](https://github.com/Orange-OpenSource/ods-ios/issues/558))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,36 @@
 # ODS library changelog
 
 All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ods-ios/compare/0.17.0...qualif)
 
-- [SDK/DemoApp] Update assets for empty state and recirculation modules ([#692] (https://github.com/Orange-OpenSource/ods-ios/issues/692))
-- [SDK] Update the tab bar configuration to see the separator ([#712] (https://github.com/Orange-OpenSource/ods-ios/issues/712))
-- [SDK/DemoApp] Create Recirculation module and update About module to use it ([#684] (https://github.com/Orange-OpenSource/ods-ios/issues/684))
+### Added
+
+- [SDK/DemoApp] Create Recirculation module and update About module to use it ([#684](https://github.com/Orange-OpenSource/ods-ios/issues/684))
+- [Tooling/DemoApp] Display build tag in about screen for beta releases (TestFlight)
+- [SDK/DemoApp] Add ODSEmptyState module ([#558](https://github.com/Orange-OpenSource/ods-ios/issues/558))
+- [Tooling] Add Git tags in CI/CD pipelines for TestFlight builds, update CocoaPods ([#680](https://github.com/Orange-OpenSource/ods-ios/issues/680))
+
+### Fixed
+
+- [SDK] Update the tab bar configuration to see the separator ([#712](https://github.com/Orange-OpenSource/ods-ios/issues/712))
 - [SDK/DemoApp] Disable vocalization of text on image in cards component ([#702](https://github.com/Orange-OpenSource/ods-ios/issues/702))
 - [DemoApp] Set focus on first item in Modules page ([#719](https://github.com/Orange-OpenSource/ods-ios/issues/719))
 - [DemoApp] Update padding in components screen when cards are in one column ([#654](https://github.com/Orange-OpenSource/ods-ios/issues/654))
-- [Tooling/DemoApp] Display build tag in about screen for beta releases (TestFlight)
-- [SDK] Group labels and associated elements in ChipsPickers ([#677](https://github.com/Orange-OpenSource/ods-ios/issues/677))
 - [DemoApp] Fix accessibility issues on the demo screen of Bars-navigation component ([#574](https://github.com/Orange-OpenSource/ods-ios/issues/574))
+- [SDK] Change the order of the accessibility focus between header and content in bottom sheet ([#703](https://github.com/Orange-OpenSource/ods-ios/issues/703))
+- [SDK] Fix expanding Bottom Sheet on iPad ([#428](https://github.com/Orange-OpenSource/ods-ios/issues/428))
+- [DemoApp] Spacer indicator missing on spacing guidelines page ([#707](https://github.com/Orange-OpenSource/ods-ios/issues/707))
+- [DemoApp] On "Customize" bottom sheets, the hint is reversed ([#704](https://github.com/Orange-OpenSource/ods-ios/issues/704))
+- [SDK] Vocalized buttons selected status with Voice Over ([#583](https://github.com/Orange-OpenSource/ods-ios/issues/583))
+- [DemoApp/SDK] Customize accordion status is not vocalized ([#581](https://github.com/Orange-OpenSource/ods-ios/issues/581))
+
+### Changed
+
+- [SDK/DemoApp] Update assets for empty state and recirculation modules ([#692](https://github.com/Orange-OpenSource/ods-ios/issues/692))
+- [SDK] Group labels and associated elements in ChipsPickers ([#677](https://github.com/Orange-OpenSource/ods-ios/issues/677))
 - [SDK] Group Labels in ODSListItems for accessibility ([#741](https://github.com/Orange-OpenSource/ods-ios/issues/741))
 - [DemoApp] Update AppIcons changed during runner migration ([#738](https://github.com/Orange-OpenSource/ods-ios/issues/738))
 - [Tooling] Update dependency SwiftFormat/CLI to v0.53.2 
@@ -21,19 +38,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [SDK] Use appIcons in recirculation module ([#698](https://github.com/Orange-OpenSource/ods-ios/issues/698))
 - [Tooling] Migration to GitLab CI runner ([#727](https://github.com/Orange-OpenSource/ods-ios/issues/727))
 - [DemoApp] Update the demo configuration for recirculation module ([#714](https://github.com/Orange-OpenSource/ods-ios/issues/714))
-- [SDK] Change the order of the accessibility focus between header and content in bottom sheet (Bug a11y [#703](https://github.com/Orange-OpenSource/ods-ios/issues/703))
-- [SDK] Update the tab bar configuration to see the separator ([#712](https://github.com/Orange-OpenSource/ods-ios/issues/712))
-- [SDK] Fix expanding Bottom Sheet on iPad (Bug [#428](https://github.com/Orange-OpenSource/ods-ios/issues/428))
-- [SDK/DemoApp] Create Recirculation module and update About module to use it ([#684](https://github.com/Orange-OpenSource/ods-ios/issues/684))
-- [DemoApp] Spacer indicator missing on spacing guidelines page (Bug [#707](https://github.com/Orange-OpenSource/ods-ios/issues/707))
-- [DemoApp] On "Customize" bottom sheets, the hint is reversed (Bug a11y [#704](https://github.com/Orange-OpenSource/ods-ios/issues/704))
-- [SDK] Update background color of the navigation and tab bars for accessibility reason (Bug [#693](https://github.com/Orange-OpenSource/ods-ios/issues/693))
-- [DemoApp] Fix wrong color of the close button (Bug [#412](https://github.com/Orange-OpenSource/ods-ios/issues/412))
+- [SDK] Update background color of the navigation and tab bars for accessibility reason ([#693](https://github.com/Orange-OpenSource/ods-ios/issues/693))
+- [DemoApp] Fix wrong color of the close button ([#412](https://github.com/Orange-OpenSource/ods-ios/issues/412))
 - [SDK] About module, Add error views for more apps and appnews ([#689](https://github.com/Orange-OpenSource/ods-ios/issues/689))
-- [SDK/DemoApp] Add ODSEmptyState module ([#558](https://github.com/Orange-OpenSource/ods-ios/issues/558))
-- [SDK] Vocalized buttons selected status with Voice Over ([#583](https://github.com/Orange-OpenSource/ods-ios/issues/583))
-- [DemoApp/SDK] Customize accordion status is not vocalized (Bug [#581](https://github.com/Orange-OpenSource/ods-ios/issues/581))
-- [Tooling] Add Git tags in CI/CD pipelines for TestFlight builds, update CocoaPods ([#680](https://github.com/Orange-OpenSource/ods-ios/issues/680))
 
 ## [0.17.0](https://github.com/Orange-OpenSource/ods-ios/compare/0.16.0...0.17.0) - 2024-07-06
 

--- a/OrangeDesignSystem/Sources/OrangeDesignSystem/Components/Lists/ODSListItem.swift
+++ b/OrangeDesignSystem/Sources/OrangeDesignSystem/Components/Lists/ODSListItem.swift
@@ -107,7 +107,7 @@ public struct ODSListItem: View {
     public enum Leading {
         /// A Solaris icon from image resource.
         case icon(Image)
- 
+
         /// An image cropped into a rounded rectangle like application icon.
         /// - Parameter source: The source of the image
         case appIcon(source: ODSImage.Source)

--- a/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Configuration/ODSAboutAccessibilityStatement.swift
+++ b/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Configuration/ODSAboutAccessibilityStatement.swift
@@ -30,7 +30,7 @@ public struct ODSAboutAccessibilityStatement {
     // MARK: Initializer
     // =================
 
-    /// Initializes the configuration for the accessibility statement."modules.about.accessibility_statement.title"
+    /// Initializes the configuration for the accessibility statement.
     ///
     /// - Parameters:
     ///    - conformityStatus: The conformity status associated to the accessibility audit, used in the menu entry, should be a localized string

--- a/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Configuration/ODSAboutAccessibilityStatement.swift
+++ b/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Configuration/ODSAboutAccessibilityStatement.swift
@@ -22,6 +22,7 @@ public struct ODSAboutAccessibilityStatement {
     // MARK: Stored Properties
     // =======================
 
+    let conformityStatus: String
     let fileName: String
     let reportDetail: URL
 
@@ -29,12 +30,14 @@ public struct ODSAboutAccessibilityStatement {
     // MARK: Initializer
     // =================
 
-    /// Initializes the configuration providing the locations of the report.
+    /// Initializes the configuration for the accessibility statement."modules.about.accessibility_statement.title"
     ///
     /// - Parameters:
+    ///    - conformityStatus: The conformity status associated to the accessibility audit, used in the menu entry, should be a localized string
     ///    - fileName: The name of the XML file contains the report of accessibility statement. By default must be stored in resources of the main bundle.
-    ///    - reportDetail: URL to get the full detail of the accessibility statement
-    public init(fileName: String, reportDetail: URL) {
+    ///    - reportDetail: URL to get the full details of the accessibility statement
+    public init(conformityStatus: String, fileName: String, reportDetail: URL) {
+        self.conformityStatus = conformityStatus
         self.fileName = fileName
         self.reportDetail = reportDetail
     }

--- a/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Internal/ListItems/AccessibilityStatement/AccessibilityStatement.swift
+++ b/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/About/Internal/ListItems/AccessibilityStatement/AccessibilityStatement.swift
@@ -30,7 +30,7 @@ struct AboutAccessibilityStatementItemConfig: ODSAboutListItemConfig {
     // =================
 
     init(statementConfig: ODSAboutAccessibilityStatement) {
-        title = °°"modules.about.accessibility_statement.title"
+        title = statementConfig.conformityStatus
         icon = Image("ic_accessibility", bundle: Bundle.ods)
         priority = .accessibilityStatement
         target = .destination(AnyView(

--- a/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/Recirculation/ODSRecirculationView.swift
+++ b/OrangeDesignSystem/Sources/OrangeDesignSystem/Modules/Recirculation/ODSRecirculationView.swift
@@ -179,7 +179,7 @@ public struct ODSRecirculation: View {
             }
         }
     }
-    
+
     private func leadingAppIcon(from appDetails: RecirculationAppDetails) -> ODSListItem.Leading? {
         guard let appIconUrl = appDetails.iconURL else {
             return nil

--- a/OrangeDesignSystem/Sources/OrangeDesignSystem/Resources/Base.lproj/Localizable.strings
+++ b/OrangeDesignSystem/Sources/OrangeDesignSystem/Resources/Base.lproj/Localizable.strings
@@ -23,7 +23,6 @@
 "modules.about.app_news.title" = "App News";
 "modules.about.privacy_policy.title" = "Privacy Policy";
 "modules.about.terms_of_service.title" = "Terms of Service";
-"modules.about.accessibility_statement.title" = "Accessibility Statement";
 "modules.about.legal_information.title" = "Legal information";
 "modules.about.rate.title" = "Rate this app";
 "modules.about.copyright" = "Orange property. All rights reserved";

--- a/OrangeDesignSystemDemo/OrangeDesignSystemDemo/Screens/About/AboutSceen.swift
+++ b/OrangeDesignSystemDemo/OrangeDesignSystemDemo/Screens/About/AboutSceen.swift
@@ -97,7 +97,10 @@ struct AboutScreen: View {
 
         privacyPolicy = ODSPrivacyPolicy.webview(.url(Bundle.main.url(forResource: "PrivacyNotice", withExtension: "html")!))
 
-        accessibilityStatement = ODSAboutAccessibilityStatement(fileName: "AccessibilityStatement", reportDetail: URL(string: "https://la-va11ydette.orange.com/")!)
+        accessibilityStatement = ODSAboutAccessibilityStatement(
+            conformityStatus: "Accessibility: partially conform",
+            fileName: "AccessibilityStatement",
+            reportDetail: URL(string: "https://la-va11ydette.orange.com/")!)
 
         customItems = [
             AboutDesignGuidelinesItemConfig(priority: 202),

--- a/OrangeDesignSystemDemo/OrangeDesignSystemDemo/Screens/Modules/About/AboutModule.swift
+++ b/OrangeDesignSystemDemo/OrangeDesignSystemDemo/Screens/Modules/About/AboutModule.swift
@@ -131,7 +131,10 @@ struct AboutModuleDemo: View {
     // ==============================
 
     let headerIllustration = ThemeProvider().imageFromResources("AboutImage")
-    let acessibilityStatement = ODSAboutAccessibilityStatement(fileName: "AccessibilityStatement", reportDetail: URL(string: "https://la-va11ydette.orange.com/")!)
+    let acessibilityStatement = ODSAboutAccessibilityStatement(
+        conformityStatus: "Accessibility: partially conform",
+        fileName: "AccessibilityStatement",
+        reportDetail: URL(string: "https://la-va11ydette.orange.com/")!)
 
     var privacyPolicy: ODSPrivacyPolicy {
         model.privacyPolicy

--- a/OrangeDesignSystemDemo/OrangeDesignSystemDemoTests/Modules/About/ODSAboutListItemPriorityTests.swift
+++ b/OrangeDesignSystemDemo/OrangeDesignSystemDemoTests/Modules/About/ODSAboutListItemPriorityTests.swift
@@ -38,7 +38,7 @@ final class ODSAboutListItemPriorityTests: XCTestCase {
         // Given
         let privacyPoliceItem = AboutPrivacyPolicyItem(policy: ODSPrivacyPolicy.webview(.url(Bundle.main.url(forResource: "PrivacyNotice", withExtension: "html")!)))
         let termOfServiceItem = AboutTermOfServiceItem(termsOfService: fakeView)
-        let accessiblityStatementItem = AboutAccessibilityStatementItemConfig(statementConfig: ODSAboutAccessibilityStatement(fileName: "AccessibilityStatement", reportDetail: URL(string: "https://la-va11ydette.orange.com/")!))
+        let accessiblityStatementItem = AboutAccessibilityStatementItemConfig(statementConfig: ODSAboutAccessibilityStatement(conformityStatus: "Accessibility: partially conform", fileName: "AccessibilityStatement", reportDetail: URL(string: "https://la-va11ydette.orange.com/")!))
         let appNewsItem = ODSAboutAppNewsItemConfig(path: "")
         let legalInformationItem = ODSAboutLegalInformationItemConfig(legalInformation: fakeView)
         let moreAppsItem = ODSRecirculationItemConfig(dataSource: .remote(url: URL(string: "https://opensource.orange.com/")!))

--- a/OrangeDesignSystemDemo/fastlane/Fastfile
+++ b/OrangeDesignSystemDemo/fastlane/Fastfile
@@ -203,6 +203,7 @@ platform :ios do
             build
         else
             puts "Nothing new to build today, a CI tag with '#{tagSuffix}' already exists"
+            publish_mattermost_notification("⚙️ 🤔 Nothing new to build today, a CI tag with '#{tagSuffix}' already exists")
         end
         
         if params[:upload]
@@ -212,6 +213,7 @@ platform :ios do
                 upload
             else
                 puts "Nothing new to build today, a TestFlight tag with '#{tagSuffix}' already exists"
+                publish_mattermost_notification("⚙️ 🤔 Nothing new to build today, a TestFlight tag with '#{tagSuffix}' already exists")
             end
         else
             puts "Upload to TestFlight not requested"
@@ -373,7 +375,6 @@ platform :ios do
             # If tag exists, CURL response is formatted like "refs/tags/tag"
             if "refs/tags/#{tag}".eql? result.strip # Removes line break avaialble in command result
                 puts "The tag '#{tag}' still exists, won't create new tag"
-                publish_mattermost_notification("⚙️ 🤔 The tag '#{tag}' still exists, won't create new tag")
                 return false
             else
                 puts "Commit SHA to tag is '#{IOS_APP_COMMIT_SHA}'"

--- a/docs/modules/about.md
+++ b/docs/modules/about.md
@@ -169,20 +169,23 @@ ODSAboutModule(applicationInformation: withFeedback, ...)
 
 #### Use mandatory items
 
-For the privacy policy display, only html content is supported today. A more structured content will be added soon.
+For the privacy policy display, only HTML content is supported today. A more structured content will be added soon.
 
 - Privacy policy
 
 ```swift
-// Initialize the privacy policy page with url of the html file store in resources. 
+// Initializes the privacy policy page with URL of the HTML file stored in resources. 
 let privacyPolicy = ODSPrivacyPolicy.webview(.url(Bundle.main.url(forResource: "PrivacyNotice", withExtension: "html")!))
 ```
 
 - The accessibility statement
 
 ```swift
-// Still it is not supported, initilaize with fake information 
-let acessibilityStatement = ODSAboutAccessibilityStatement(reportPath: "path", reportDetail: URL(string: "https://www.apple.com")!)
+// Defines an item displaying as a title the "conformity status" text, parsing the file named "fileName" and sending user elsewhere for further details
+let accessibilityStatement = ODSAboutAccessibilityStatement(
+    conformityStatus: "Accessibility: partially conform",
+    fileName: "AccessibilityStatement",
+    reportDetail: URL(string: "https://la-va11ydette.orange.com/")!)
 ```
 
 - The Terms of service


### PR DESCRIPTION
- Display accessibility conformity status in menu instead of title (#772)
- Move Mattermost notification about already created tag (Fastfile)
- Fix some warnings (SwiftLint)
- Apply keep-a-changelog rules (CHANGELOG)